### PR TITLE
fixed yaml float loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ SIM.run()
 ```
 
 
+## Input
+
+
+## Output
+
+
 ## Changelog
 
 * v1.2.0 

--- a/examples/testbeam1.yml
+++ b/examples/testbeam1.yml
@@ -24,9 +24,9 @@ beam:
   emittanceY:   0.0           # mm mrad
   sigmaX:       5.            # micron, transverse beam size
   sigmaY:       5.            # micron, transverse beam size
-  sigmaL:       20.           # micron, longitduinal beam size
-  beam_charge:  100e-12       # beam charge in Coulomb
-  beam_focus_z: 0             # Focus position of electron beam, 0 = ICS interaction point, in microns
+  sigmaZ:       20.           # micron, longitduinal beam size
+  charge:       100e-12       # beam charge in Coulomb
+  focus_z:      0             # Focus position of electron beam, 0 = ICS interaction point, in microns
   baseline:     7.5e6         # Distance between ICS and Stong IP in microns
 
 
@@ -41,8 +41,7 @@ laser:
 
 
 detector:                           # spectrum calculation
-  pdim:  3                          # number of detector dimensions for spectrum calculation
-  omega: [1.5e9,4.5e9]               # [omegamin,omegamax] , eV
-  theta: [0,50e-6]                 # [thetamin,thetamax] , rad
+  omega: [1.5e9,4.5e9]              # [omegamin,omegamax] , eV
+  theta: [0,50e-6]                  # [thetamin,thetamax] , rad
   phi:   [0.0,6.283185307179586]    # [phimin,phimax]     , rad
 

--- a/examples/testbeam2.yml
+++ b/examples/testbeam2.yml
@@ -24,9 +24,9 @@ beam:
   emittanceY:   1.5           # mm mrad
   sigmaX:       5.            # micron, transverse beam size
   sigmaY:       5.            # micron, transverse beam size
-  sigmaL:       20.           # micron, longitduinal beam size
-  beam_charge:  100e-12       # beam charge in Coulomb
-  beam_focus_z: 0             # Focus position of electron beam, 0 = ICS interaction point, in microns
+  sigmaZ:       20.           # micron, longitduinal beam size
+  charge:       100e-12       # beam charge in Coulomb
+  focus_z:      0             # Focus position of electron beam, 0 = ICS interaction point, in microns
   baseline:     7.5e6         # Distance between ICS and Stong IP in microns
 
 
@@ -41,7 +41,6 @@ laser:
 
 
 detector:                           # spectrum calculation
-  pdim:  3                          # number of detector dimensions for spectrum calculation
   omega: [1.5e9,4.5e9]               # [omegamin,omegamax] , eV
   theta: [0,50e-6]                 # [thetamin,thetamax] , rad
   phi:   [0.0,6.283185307179586]    # [phimin,phimax]     , rad

--- a/examples/testbeam3.yml
+++ b/examples/testbeam3.yml
@@ -24,9 +24,9 @@ beam:
   emittanceY:   1.5           # mm mrad
   sigmaX:       10.           # micron, transverse beam size
   sigmaY:       10.           # micron, transverse beam size
-  sigmaL:       20.           # micron, longitduinal beam size
-  beam_charge:  100e-12       # beam charge in Coulomb
-  beam_focus_z: 0             # Focus position of electron beam, 0 = ICS interaction point, in microns
+  sigmaZ:       20.           # micron, longitduinal beam size
+  charge:       100e-12       # beam charge in Coulomb
+  focus_z:      0             # Focus position of electron beam, 0 = ICS interaction point, in microns
   baseline:     7.5e6         # Distance between ICS and Stong IP in microns
 
 
@@ -41,7 +41,6 @@ laser:
 
 
 detector:                           # spectrum calculation
-  pdim:  3                          # number of detector dimensions for spectrum calculation
   omega: [1.5e9,4.5e9]               # [omegamin,omegamax] , eV
   theta: [0,50e-6]                 # [thetamin,thetamax] , rad
   phi:   [0.0,6.283185307179586]    # [phimin,phimax]     , rad

--- a/pica/__init__.py
+++ b/pica/__init__.py
@@ -6,4 +6,17 @@ import numpy as np
 from .constants import *
 from .collisions import *
 
-# __version__ = read('__version__.py')
+
+import re
+float_loader = yaml.SafeLoader
+float_loader.add_implicit_resolver(
+    u'tag:yaml.org,2002:float',
+    re.compile(u'''^(?:
+     [-+]?(?:[0-9][0-9_]*)\\.[0-9_]*(?:[eE][-+]?[0-9]+)?
+    |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
+    |\\.[0-9_]+(?:[eE][-+][0-9]+)?
+    |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*
+    |[-+]?\\.(?:inf|Inf|INF)
+    |\\.(?:nan|NaN|NAN))$''', re.X),
+    list(u'-+0123456789.'))
+

--- a/pica/collisions.py
+++ b/pica/collisions.py
@@ -94,7 +94,7 @@ class ICSSimulation(H5Writer, H5Reader, ICSAnalysis):
         # else:
         #     raise ValueError
 
-        self.number_electrons = self.config.beam.beam_charge / elementary_charge_si
+        self.number_electrons = self.config.beam.charge / elementary_charge_si
         self.electron_weight  = self.number_electrons / self.config.control.beam.sample_electrons
 
 
@@ -172,10 +172,10 @@ class ICSSimulation(H5Writer, H5Reader, ICSAnalysis):
         #Mean and Covariant matrices for bivariate gaussian
         
         mean_x = [0,0]  # x-offset and x' offset for focus 
-        cov_x = beam_covariance_matrix(self.config.beam.sigmaX, rms_angle_X, self.config.beam.beam_focus_z )
+        cov_x = beam_covariance_matrix(self.config.beam.sigmaX, rms_angle_X, self.config.beam.focus_z )
 
         mean_y = [0,0]  # y-offset and y' offset for focus
-        cov_y = beam_covariance_matrix(self.config.beam.sigmaY, rms_angle_Y, self.config.beam.beam_focus_z )
+        cov_y = beam_covariance_matrix(self.config.beam.sigmaY, rms_angle_Y, self.config.beam.focus_z )
 
         
         #Sampling (x,x') and (y,y')
@@ -269,7 +269,7 @@ class ICSSimulation(H5Writer, H5Reader, ICSAnalysis):
         sampled_x       = x[selector1]
         sampled_y       = y[selector1]
 
-        sampled_zeta    = np.random.normal( 0 , self.config.beam.sigmaL  , number_photons )
+        sampled_zeta    = np.random.normal( 0 , self.config.beam.sigmaZ  , number_photons )
         sampled_z       = +0.5 * sampled_zeta
         sampled_t       = -0.5 * sampled_zeta
 
@@ -352,7 +352,7 @@ class ICSSimulation(H5Writer, H5Reader, ICSAnalysis):
 #######################################################################################################################################
 
 
-
+"""
 class AtomicSimulation(H5Writer, H5Reader, ICSAnalysis):
 
     def __init__(self, input_filename ):
@@ -659,6 +659,6 @@ class AtomicSimulation(H5Writer, H5Reader, ICSAnalysis):
 
 
         print ('   total photon number:',len(self.W_electron))
-
+"""
 
 

--- a/pica/inout.py
+++ b/pica/inout.py
@@ -26,12 +26,12 @@ final-state
 
 @dataclass
 class Control_Beam:
-    sample_electrons: float | str | int
-    sample_batch_size: float | str | int = '1e7'
+    sample_electrons: float 
+    sample_batch_size: float = 1e7
         
     def __post_init__(self):
-        self.sample_electrons  = int(float(self.sample_electrons))
-        self.sample_batch_size = int(float(self.sample_batch_size))
+        self.sample_electrons  = int( self.sample_electrons)
+        self.sample_batch_size = int( self.sample_batch_size)
 
 @dataclass
 class Control_Laser:
@@ -43,8 +43,8 @@ class Control_Detector:
 
 @dataclass
 class Control:
-    sampling: str
-    xsection: str
+    # sampling: str
+    # xsection: str
     beam: Control_Beam
     laser: Control_Laser
     detector: Control_Detector
@@ -72,29 +72,17 @@ class Unit:
 
 @dataclass
 class Beam:
-    gamma: float | str
-    energyspread: float | str
-    emittanceX: float | str
-    emittanceY: float | str
-    sigmaX: float | str
-    sigmaY: float | str
-    sigmaL: float | str
-    beam_charge: float | str
-    beam_focus_z: float | str
-    baseline: float | str
+    gamma: float
+    energyspread: float 
+    emittanceX: float 
+    emittanceY: float
+    sigmaX: float
+    sigmaY: float
+    sigmaZ: float
+    charge: float
+    focus_z: float
+    baseline: float
         
-    def __post_init__(self):
-        self.gamma        = float(self.gamma)
-        self.energyspread = float(self.energyspread)
-        self.emittanceX   = float(self.emittanceX)
-        self.emittanceY   = float(self.emittanceY)
-        self.sigmaX       = float(self.sigmaX)
-        self.sigmaY       = float(self.sigmaY)
-        self.sigmaL       = float(self.sigmaL)
-        self.beam_charge  = float(self.beam_charge)
-        self.beam_focus_z = float(self.beam_focus_z)
-        self.baseline     = float(self.baseline)
-
 @dataclass
 class Laser:
     a0: float
@@ -115,15 +103,9 @@ class Laser:
 
 @dataclass
 class Detector:
-    # pdim:  int
-    omega: list[float | str]
-    theta: list[float | str]
-    phi:   list[float | str]
-
-    def __post_init__(self):
-        self.omega = [float(i) for i in self.omega]
-        self.theta = [float(i) for i in self.theta]
-        self.phi   = [float(i) for i in self.phi  ]
+    omega: list[float]
+    theta: list[float]
+    phi:   list[float]
 
 
         
@@ -137,50 +119,6 @@ class PICA_Config:
     detector: Detector
  
 
-
-
-
-# class ParameterReader():
-
-#     def __init__(self):
-#         pass
-
-#     def read_laser_parameters(self):
-
-
-#         self.omega0    = float( self.input_dict['laser']['omega0']  )
-#         self.a0        = float( self.input_dict['laser']['a0']      )
-#         self.TFWHM     = float( self.input_dict['laser']['TFWHM']  )
-#         self.w0        = float( self.input_dict['laser']['w0']      )
-#         self.poldegree = float( self.input_dict['laser']['poldegree']   )
-#         self.polangle  = float( self.input_dict['laser']['polangle']    )
-#         self.pulse     = self.input_dict['laser']['pulse']
-
-#         if self.pulse!='cos2':
-#             raise NotImplementedError
-
-
-
-#     def read_beam_parameters(self):
-#         # extracting beam parameters from the YML File
-#         self.gamma0       = float( self.input_dict['beam']['gamma'] )
-#         self.energyspread = float( self.input_dict['beam']['energyspread'] )
-#         self.emittance_X  = float( self.input_dict['beam']['emittanceX'] )
-#         self.emittance_Y  = float( self.input_dict['beam']['emittanceY'] )
-#         self.beam_size_X  = float( self.input_dict['beam']['sigmaX'] )        # transverse beam size x axis in microns
-#         self.beam_size_Y  = float( self.input_dict['beam']['sigmaY'] )        # transverse beam size y axis in microns
-#         self.beam_length  = float( self.input_dict['beam']['sigmaL'] )        # longitudinal beam size in microns 
-#         self.beam_charge  = float( self.input_dict['beam']['beam_charge'])
-#         self.beam_focus_z = float( self.input_dict['beam']['beam_focus_z'])
-#         self.baseline     = float( self.input_dict['beam']['baseline'])
-
-#     def read_detector(self):
-
-#         # extract detector parameters
-#         self.pdim           = int(self.input_dict['detector']['pdim'])
-#         self.omega_detector = [float(w) for w in self.input_dict['detector']['omega']]
-#         self.theta_detector = [float(t) for t in self.input_dict['detector']['theta']]
-#         self.phi_detector   = [float(p) for p in self.input_dict['detector']['phi']]
 
 
 class H5Writer():


### PR DESCRIPTION
The issues was actually caused by the yaml.SafeLoader which in some cases loads scientific notation floats as strings. The problem was solved by an obscure regex that was added in the __init__.py

```
loader.add_implicit_resolver(
    u'tag:yaml.org,2002:float',
    re.compile(u'''^(?:
     [-+]?(?:[0-9][0-9_]*)\\.[0-9_]*(?:[eE][-+]?[0-9]+)?
    |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
    |\\.[0-9_]+(?:[eE][-+][0-9]+)?
    |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*
    |[-+]?\\.(?:inf|Inf|INF)
    |\\.(?:nan|NaN|NAN))$''', re.X),
    list(u'-+0123456789.'))
```

Solution from https://stackoverflow.com/questions/30458977/yaml-loads-5e-6-as-string-and-not-a-number